### PR TITLE
Victron Lynx VE.CAN Shunt + bugfixes

### DIFF
--- a/CONFIG.H
+++ b/CONFIG.H
@@ -91,9 +91,9 @@ typedef struct {
   uint16_t UnderDur;
   uint16_t CurDead;
   float DisTaper;
-  bool ChargerDirect;
-  bool ExpMess;
-  bool SerialCan;
+  uint8_t ChargerDirect; // bool
+  uint8_t ExpMess; // bool
+  uint8_t SerialCan; // bool
   uint16_t PulseCh;
   uint16_t PulseChDur;
   uint16_t PulseDi;

--- a/TeslaBMSV2.ino
+++ b/TeslaBMSV2.ino
@@ -2696,7 +2696,7 @@ void menu()
     }
   }
 
-  if (incomingByte == 115 & menuload == 0)
+  if (incomingByte == 115 && menuload == 0)
   {
     SERIALCONSOLE.println();
     SERIALCONSOLE.println("MENU");

--- a/TeslaBMSV2.ino
+++ b/TeslaBMSV2.ino
@@ -2829,6 +2829,7 @@ void CAB300()
 
 void handleVictronLynx()
 {
+	if(inMsg.buf[4] == 0xff && inMsg.buf[3] == 0xff) return;
 	int16_t current = (int)inMsg.buf[4] << 8; // in 0.1A increments
 	current |= inMsg.buf[3];
 	CANmilliamps = current * 100;


### PR DESCRIPTION
Added CAN parsing for the Victron Lynx VE.CAN shunt for current measurement.

Also fixed a couple of bugs: one logical error with & instead of && in a comparison, and also that booleans were not being saved/interpreted correctly in EEPROM settings. They were getting saved/returned as 254 when false and 255 when true (because unused bits were left as 1), so they were always being interpreted as true (since 254 != 0). I just changed them in the struct to uint8_t which takes the same space as the bool in the EEPROM, but forces unused bits to zero.