### PR TITLE
Send VEcan messages the configurable schedule used for charger CAN messages

### DIFF
--- a/TeslaBMSV2.ino
+++ b/TeslaBMSV2.ino
@@ -973,7 +973,6 @@ void loop()
     }
     updateSOC();
     currentlimit();
-    VEcan();
 
     if (settings.ESSmode == 1 && settings.ChargerDirect == 0 && CanOnRev == true)
     {
@@ -1021,6 +1020,7 @@ void loop()
   if (millis() - looptime1 > settings.chargerspd)
   {
     looptime1 = millis();
+    VEcan();
     if (settings.ESSmode == 1)
     {
       chargercomms();


### PR DESCRIPTION
This allows more flexibility to send VE compatible CAN messages more frequently which can be useful for gauge displays. This could have its own configurable period, but this fix seems sufficient.